### PR TITLE
feat: adapt to rush 1.0.0 API

### DIFF
--- a/.github/workflows/no-suggest-cmd-check.yml
+++ b/.github/workflows/no-suggest-cmd-check.yml
@@ -1,4 +1,5 @@
-# r cmd check workflow of the mlr3 ecosystem v0.6.0
+# R CMD check workflow without suggested packages v0.4.0
+# Without `cache: false` packages can leak from the cache of the previous workflow runs
 # You can remove the `services.redis` section if the package does not require `rush` for the tests
 # https://github.com/mlr-org/actions
 on:
@@ -16,10 +17,10 @@ on:
     branches:
       - main
 
-name: r-cmd-check
+name: no-suggest-cmd-check
 
 jobs:
-  r-cmd-check:
+  no-suggest-cmd-check:
     runs-on: ${{ matrix.config.os }}
     services:
       redis:
@@ -42,7 +43,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,   r: 'devel'}
           - {os: ubuntu-latest,   r: 'release'}
 
     steps:
@@ -56,8 +56,14 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
           needs: check
+          dependencies: '"hard"'
+          cache: false
 
       - uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
@@ -66,5 +72,4 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          error-on: '"note"'
           args: 'c("--no-manual", "--as-cran")'

--- a/.github/workflows/no-suggest-cmd-check.yml
+++ b/.github/workflows/no-suggest-cmd-check.yml
@@ -72,4 +72,4 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--no-manual", "--as-cran")'
+          args: 'c("--no-manual")' # "--as-cran" prevents to start external processes

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -67,4 +67,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           error-on: '"note"'
-          args: 'c("--no-manual", "--as-cran")'
+          args: 'c("--no-manual")' # "--as-cran" prevents to start external processes

--- a/R/LearnerClassifAuto.R
+++ b/R/LearnerClassifAuto.R
@@ -20,16 +20,22 @@ LearnerClassifAuto = R6Class("LearnerClassifAuto",
     #' @field instance ([mlr3tuning::TuningInstanceAsyncSingleCrit]).
     instance = NULL,
 
+    #' @field rush ([rush::Rush])\cr
+    #' Rush instance for parallel tuning.
+    rush = NULL,
+
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function(
       id = "classif.auto",
-      learner_ids
+      learner_ids,
+      rush = NULL
       ) {
       all_learner_ids = mlr_auto$keys()
       if (missing(learner_ids)) learner_ids = all_learner_ids
       assert_subset(learner_ids, all_learner_ids)
       private$.learner_ids = learner_ids
+      self$rush = assert_r6(rush, "Rush", null.ok = TRUE)
 
       param_set = ps(
         learner_timeout = p_int(lower = 1L, init = 900L, tags = c("train", "super")),

--- a/R/LearnerClassifAutoCatboost.R
+++ b/R/LearnerClassifAutoCatboost.R
@@ -12,8 +12,8 @@ LearnerClassifAutoCatboost = R6Class("LearnerClassifAutoCatboost",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_catboost") {
-      super$initialize(id = id, learner_ids = "catboost")
+    initialize = function(id = "classif.auto_catboost", rush = NULL) {
+      super$initialize(id = id, learner_ids = "catboost", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoFTTransformer.R
+++ b/R/LearnerClassifAutoFTTransformer.R
@@ -12,8 +12,8 @@ LearnerClassifAutoFTTransformer = R6Class("LearnerClassifAutoFTTransformer",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_ft_transformer") {
-      super$initialize(id = id, learner_ids = "ft_transformer")
+    initialize = function(id = "classif.auto_ft_transformer", rush = NULL) {
+      super$initialize(id = id, learner_ids = "ft_transformer", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoFastai.R
+++ b/R/LearnerClassifAutoFastai.R
@@ -12,8 +12,8 @@ LearnerClassifAutoFastai = R6Class("LearnerClassifAutoFastai",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_fastai") {
-      super$initialize(id = id, learner_ids = "fastai")
+    initialize = function(id = "classif.auto_fastai", rush = NULL) {
+      super$initialize(id = id, learner_ids = "fastai", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoGlmnet.R
+++ b/R/LearnerClassifAutoGlmnet.R
@@ -12,8 +12,8 @@ LearnerClassifAutoGlmnet = R6Class("LearnerClassifAutoGlmnet",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_glmnet") {
-      super$initialize(id = id, learner_ids = "glmnet")
+    initialize = function(id = "classif.auto_glmnet", rush = NULL) {
+      super$initialize(id = id, learner_ids = "glmnet", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoKKNN.R
+++ b/R/LearnerClassifAutoKKNN.R
@@ -12,8 +12,8 @@ LearnerClassifAutoKKNN = R6Class("LearnerClassifAutoKKNN",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_kknn") {
-      super$initialize(id = id, learner_ids = "kknn")
+    initialize = function(id = "classif.auto_kknn", rush = NULL) {
+      super$initialize(id = id, learner_ids = "kknn", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoLightGBM.R
+++ b/R/LearnerClassifAutoLightGBM.R
@@ -12,8 +12,8 @@ LearnerClassifAutoLightGBM = R6Class("LearnerClassifAutoLightGBM",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_lightgbm") {
-      super$initialize(id = id, learner_ids = "lightgbm")
+    initialize = function(id = "classif.auto_lightgbm", rush = NULL) {
+      super$initialize(id = id, learner_ids = "lightgbm", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoMLP.R
+++ b/R/LearnerClassifAutoMLP.R
@@ -12,8 +12,8 @@ LearnerClassifAutoMLP = R6Class("LearnerClassifAutoMLP",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_mlp") {
-      super$initialize(id = id, learner_ids = "mlp")
+    initialize = function(id = "classif.auto_mlp", rush = NULL) {
+      super$initialize(id = id, learner_ids = "mlp", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoRanger.R
+++ b/R/LearnerClassifAutoRanger.R
@@ -12,8 +12,8 @@ LearnerClassifAutoRanger = R6Class("LearnerClassifAutoRanger",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_ranger") {
-      super$initialize(id = id, learner_ids = "ranger")
+    initialize = function(id = "classif.auto_ranger", rush = NULL) {
+      super$initialize(id = id, learner_ids = "ranger", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoResNet.R
+++ b/R/LearnerClassifAutoResNet.R
@@ -12,8 +12,8 @@ LearnerClassifAutoResNet = R6Class("LearnerClassifAutoResNet",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_resnet") {
-      super$initialize(id = id, learner_ids = "resnet")
+    initialize = function(id = "classif.auto_resnet", rush = NULL) {
+      super$initialize(id = id, learner_ids = "resnet", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoSVM.R
+++ b/R/LearnerClassifAutoSVM.R
@@ -12,8 +12,8 @@ LearnerClassifAutoSVM = R6Class("LearnerClassifAutoSVM",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_svm") {
-      super$initialize(id = id, learner_ids = "svm")
+    initialize = function(id = "classif.auto_svm", rush = NULL) {
+      super$initialize(id = id, learner_ids = "svm", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoTabPFN.R
+++ b/R/LearnerClassifAutoTabPFN.R
@@ -12,8 +12,8 @@ LearnerClassifAutoTabPFN = R6Class("LearnerClassifAutoTabPFN",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_tabpfn") {
-      super$initialize(id = id, learner_ids = "tabpfn")
+    initialize = function(id = "classif.auto_tabpfn", rush = NULL) {
+      super$initialize(id = id, learner_ids = "tabpfn", rush = rush)
     }
   )
 )

--- a/R/LearnerClassifAutoXgboost.R
+++ b/R/LearnerClassifAutoXgboost.R
@@ -12,8 +12,8 @@ LearnerClassifAutoXgboost = R6Class("LearnerClassifAutoXgboost",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "classif.auto_xgboost") {
-      super$initialize(id = id, learner_ids = "xgboost")
+    initialize = function(id = "classif.auto_xgboost", rush = NULL) {
+      super$initialize(id = id, learner_ids = "xgboost", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAuto.R
+++ b/R/LearnerRegrAuto.R
@@ -20,16 +20,22 @@ LearnerRegrAuto = R6Class("LearnerRegrAuto",
     #' @field instance ([mlr3tuning::TuningInstanceAsyncSingleCrit]).
     instance = NULL,
 
+    #' @field rush ([rush::Rush])\cr
+    #' Rush instance for parallel tuning.
+    rush = NULL,
+
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function(
       id = "regr.auto",
-      learner_ids
+      learner_ids,
+      rush = NULL
       ) {
       all_learner_ids = mlr_auto$keys()
       if (missing(learner_ids)) learner_ids = all_learner_ids
       assert_subset(learner_ids, all_learner_ids)
       private$.learner_ids = learner_ids
+      self$rush = assert_r6(rush, "Rush", null.ok = TRUE)
 
       param_set = ps(
         learner_timeout = p_int(lower = 1L, init = 900L, tags = c("train", "super")),

--- a/R/LearnerRegrAutoCatboost.R
+++ b/R/LearnerRegrAutoCatboost.R
@@ -12,8 +12,8 @@ LearnerRegrAutoCatboost = R6Class("LearnerRegrAutoCatboost",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_catboost") {
-      super$initialize(id = id, learner_ids = "catboost")
+    initialize = function(id = "regr.auto_catboost", rush = NULL) {
+      super$initialize(id = id, learner_ids = "catboost", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoExtraTrees.R
+++ b/R/LearnerRegrAutoExtraTrees.R
@@ -12,8 +12,8 @@ LearnerRegrAutoExtraTrees = R6Class("LearnerRegrAutoExtraTrees",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_extra_trees") {
-      super$initialize(id = id, learner_ids = "extra_trees")
+    initialize = function(id = "regr.auto_extra_trees", rush = NULL) {
+      super$initialize(id = id, learner_ids = "extra_trees", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoFTTransformer.R
+++ b/R/LearnerRegrAutoFTTransformer.R
@@ -12,8 +12,8 @@ LearnerRegrAutoFTTransformer = R6Class("LearnerRegrAutoFTTransformer",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_ft_transformer") {
-      super$initialize(id = id, learner_ids = "ft_transformer")
+    initialize = function(id = "regr.auto_ft_transformer", rush = NULL) {
+      super$initialize(id = id, learner_ids = "ft_transformer", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoFastai.R
+++ b/R/LearnerRegrAutoFastai.R
@@ -12,8 +12,8 @@ LearnerRegrAutoFastai = R6Class("LearnerRegrAutoFastai",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_fastai") {
-      super$initialize(id = id, learner_ids = "fastai")
+    initialize = function(id = "regr.auto_fastai", rush = NULL) {
+      super$initialize(id = id, learner_ids = "fastai", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoGlmnet.R
+++ b/R/LearnerRegrAutoGlmnet.R
@@ -12,8 +12,8 @@ LearnerRegrAutoGlmnet = R6Class("LearnerRegrAutoGlmnet",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_glmnet") {
-      super$initialize(id = id, learner_ids = "glmnet")
+    initialize = function(id = "regr.auto_glmnet", rush = NULL) {
+      super$initialize(id = id, learner_ids = "glmnet", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoKKNN.R
+++ b/R/LearnerRegrAutoKKNN.R
@@ -12,8 +12,8 @@ LearnerRegrAutoKKNN = R6Class("LearnerRegrAutoKKNN",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_kknn") {
-      super$initialize(id = id, learner_ids = "kknn")
+    initialize = function(id = "regr.auto_kknn", rush = NULL) {
+      super$initialize(id = id, learner_ids = "kknn", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoLightGBM.R
+++ b/R/LearnerRegrAutoLightGBM.R
@@ -12,8 +12,8 @@ LearnerRegrAutoLightGBM = R6Class("LearnerRegrAutoLightGBM",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_lightgbm") {
-      super$initialize(id = id, learner_ids = "lightgbm")
+    initialize = function(id = "regr.auto_lightgbm", rush = NULL) {
+      super$initialize(id = id, learner_ids = "lightgbm", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoMLP.R
+++ b/R/LearnerRegrAutoMLP.R
@@ -12,8 +12,8 @@ LearnerRegrAutoMLP = R6Class("LearnerRegrAutoMLP",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_mlp") {
-      super$initialize(id = id, learner_ids = "mlp")
+    initialize = function(id = "regr.auto_mlp", rush = NULL) {
+      super$initialize(id = id, learner_ids = "mlp", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoRanger.R
+++ b/R/LearnerRegrAutoRanger.R
@@ -12,8 +12,8 @@ LearnerRegrAutoRanger = R6Class("LearnerRegrAutoRanger",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_ranger") {
-      super$initialize(id = id, learner_ids = "ranger")
+    initialize = function(id = "regr.auto_ranger", rush = NULL) {
+      super$initialize(id = id, learner_ids = "ranger", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoResNet.R
+++ b/R/LearnerRegrAutoResNet.R
@@ -12,8 +12,8 @@ LearnerRegrAutoResNet = R6Class("LearnerRegrAutoResNet",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_resnet") {
-      super$initialize(id = id, learner_ids = "resnet")
+    initialize = function(id = "regr.auto_resnet", rush = NULL) {
+      super$initialize(id = id, learner_ids = "resnet", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoSVM.R
+++ b/R/LearnerRegrAutoSVM.R
@@ -12,8 +12,8 @@ LearnerRegrAutoSVM = R6Class("LearnerRegrAutoSVM",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_svm") {
-      super$initialize(id = id, learner_ids = "svm")
+    initialize = function(id = "regr.auto_svm", rush = NULL) {
+      super$initialize(id = id, learner_ids = "svm", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoTabPFN.R
+++ b/R/LearnerRegrAutoTabPFN.R
@@ -12,8 +12,8 @@ LearnerRegrAutoTabPFN = R6Class("LearnerRegrAutoTabPFN",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_tabpfn") {
-      super$initialize(id = id, learner_ids = "tabpfn")
+    initialize = function(id = "regr.auto_tabpfn", rush = NULL) {
+      super$initialize(id = id, learner_ids = "tabpfn", rush = rush)
     }
   )
 )

--- a/R/LearnerRegrAutoXgboost.R
+++ b/R/LearnerRegrAutoXgboost.R
@@ -12,8 +12,8 @@ LearnerRegrAutoXgboost = R6Class("LearnerRegrAutoXgboost",
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    initialize = function(id = "regr.auto_xgboost") {
-      super$initialize(id = id, learner_ids = "xgboost")
+    initialize = function(id = "regr.auto_xgboost", rush = NULL) {
+      super$initialize(id = id, learner_ids = "xgboost", rush = rush)
     }
   )
 )

--- a/R/train_auto.R
+++ b/R/train_auto.R
@@ -79,7 +79,8 @@ train_auto = function(self, private, task) {
     search_space = search_space,
     callbacks = callbacks,
     store_benchmark_result = pv$store_benchmark_result,
-    store_models = pv$store_models
+    store_models = pv$store_models,
+    rush = self$rush
   )
 
   # initial design

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ remotes::install_github("mlr-org/mlr3automl")
 ```{r eval = FALSE}
 library("mlr3automl")
 
-rush_plan(n_workers = 2, worker_type = "remote")
+rush_plan(n_workers = 2, worker_type = "mirai")
 mirai::daemons(2)
 
 task = tsk("spam")

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,6 @@ Package website: [release](https://mlr3automl.mlr-org.com/) | [dev](https://mlr3
 <!-- badges: start -->
 [![r-cmd-check](https://github.com/mlr-org/mlr3automl/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/mlr-org/mlr3automl/actions/workflows/r-cmd-check.yml)
 [![CRAN Status](https://www.r-pkg.org/badges/version-ago/mlr3automl)](https://cran.r-project.org/package=mlr3automl)
-[![StackOverflow](https://img.shields.io/badge/stackoverflow-mlr3-orange.svg)](https://stackoverflow.com/questions/tagged/mlr3)
 [![Mattermost](https://img.shields.io/badge/chat-mattermost-orange.svg)](https://lmmisld-lmu-stats-slds.srv.mwn.de/mlr_invite/)
 <!-- badges: end -->
 
@@ -37,7 +36,7 @@ The optimization is driven by Asynchronous Decentralized Bayesian Optimization (
 Install the development version from GitHub:
 
 ```{r eval = FALSE}
-remotes::install_github("mlr-org/mlr3automl")
+pak::pkg_install("mlr-org/mlr3automl")
 ```
 
 ## Examples
@@ -55,4 +54,13 @@ learner = lrn("classif.auto",
 )
 
 learner$train(task)
+```
+
+## Test with Redis
+
+To test the package, set the `RUSH_TEST_USE_REDIS` environment variable to `true`.
+The test suite deletes the Redis database before execution, so never run it against a production server.
+
+```{r eval = FALSE}
+Sys.setenv(RUSH_TEST_USE_REDIS = "true")
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Package website: [release](https://mlr3automl.mlr-org.com/) \|
 [![r-cmd-check](https://github.com/mlr-org/mlr3automl/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/mlr-org/mlr3automl/actions/workflows/r-cmd-check.yml)
 [![CRAN
 Status](https://www.r-pkg.org/badges/version-ago/mlr3automl)](https://cran.r-project.org/package=mlr3automl)
-[![StackOverflow](https://img.shields.io/badge/stackoverflow-mlr3-orange.svg)](https://stackoverflow.com/questions/tagged/mlr3)
 [![Mattermost](https://img.shields.io/badge/chat-mattermost-orange.svg)](https://lmmisld-lmu-stats-slds.srv.mwn.de/mlr_invite/)
 <!-- badges: end -->
 
@@ -30,7 +29,7 @@ efficient and scalable AutoML.
 Install the development version from GitHub:
 
 ``` r
-remotes::install_github("mlr-org/mlr3automl")
+pak::pkg_install("mlr-org/mlr3automl")
 ```
 
 ## Examples
@@ -38,8 +37,8 @@ remotes::install_github("mlr-org/mlr3automl")
 ``` r
 library("mlr3automl")
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+rush_plan(n_workers = 2, worker_type = "mirai")
+mirai::daemons(2)
 
 task = tsk("spam")
 
@@ -48,4 +47,14 @@ learner = lrn("classif.auto",
 )
 
 learner$train(task)
+```
+
+## Test with Redis
+
+To test the package, set the `RUSH_TEST_USE_REDIS` environment variable
+to `true`. The test suite deletes the Redis database before execution,
+so never run it against a production server.
+
+``` r
+Sys.setenv(RUSH_TEST_USE_REDIS = "true")
 ```

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -7,23 +7,7 @@ library(R6)
 
 lapply(list.files(system.file("testthat", package = "mlr3"), pattern = "^helper.*\\.[rR]", full.names = TRUE), source)
 lapply(list.files(system.file("testthat", package = "mlr3tuning"), pattern = "^helper.*\\.[rR]", full.names = TRUE), source)
-
-flush_redis = function() {
-  config = redux::redis_config()
-  r = redux::hiredis(config)
-  r$FLUSHDB()
-}
-
-expect_rush_reset = function(rush, type = "kill") {
-  rush$reset(type = type)
-  Sys.sleep(1)
-  keys = rush$connector$command(c("KEYS", "*"))
-  if (!test_list(keys, len = 0)) {
-    stopf("Found keys in redis after reset: %s", keys)
-  }
-  mirai::daemons(0)
-}
-
+lapply(list.files(system.file("testthat", package = "rush"), pattern = "^helper.*\\.[rR]", full.names = TRUE), source)
 
 test_classif_learner = function(
   learner_id,
@@ -36,14 +20,18 @@ test_classif_learner = function(
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget(learner_id), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = if (is.null(task)) tsk("penguins") else task
   learner = lrn("classif.auto",
     learner_ids = learner_id,
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),
@@ -73,14 +61,18 @@ test_regr_learner = function(
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget(learner_id), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = if (is.null(task)) tsk("mtcars") else task
   learner = lrn("regr.auto",
     learner_ids = learner_id,
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -9,6 +9,10 @@ lapply(list.files(system.file("testthat", package = "mlr3"), pattern = "^helper.
 lapply(list.files(system.file("testthat", package = "mlr3tuning"), pattern = "^helper.*\\.[rR]", full.names = TRUE), source)
 lapply(list.files(system.file("testthat", package = "rush"), pattern = "^helper.*\\.[rR]", full.names = TRUE), source)
 
+skip_if_not_all_installed = function(pkgs) {
+  for (pkg in pkgs) skip_if_not_installed(pkg)
+}
+
 test_classif_learner = function(
   learner_id,
   initial_design_size = 2,
@@ -18,7 +22,7 @@ test_classif_learner = function(
   check_learners = TRUE
   ) {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget(learner_id), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget(learner_id), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 
@@ -59,7 +63,7 @@ test_regr_learner = function(
   check_learners = TRUE
   ) {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget(learner_id), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget(learner_id), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_Auto.R
+++ b/tests/testthat/test_Auto.R
@@ -1,5 +1,5 @@
 test_that("default design is generated", {
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
 
   autos = mlr_auto$mget(mlr_auto$keys())
   xdt = map_dtr(autos, function(auto) auto$design_default(tsk("penguins")), .fill = TRUE)
@@ -8,7 +8,7 @@ test_that("default design is generated", {
 })
 
 test_that("lhs design is generated", {
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
 
   autos = mlr_auto$mget(mlr_auto$keys())
   xdt = generate_initial_design("lhs", combine_search_spaces(autos, tsk("penguins")), 256L)
@@ -17,7 +17,7 @@ test_that("lhs design is generated", {
 })
 
 test_that("sobol design is generated", {
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
 
   autos = mlr_auto$mget(mlr_auto$keys())
   xdt = generate_initial_design("sobol", combine_search_spaces(autos, tsk("penguins")), 256L)
@@ -26,7 +26,7 @@ test_that("sobol design is generated", {
 })
 
 test_that("random design is generated", {
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
 
   autos = mlr_auto$mget(mlr_auto$keys())
   xdt = generate_initial_design("random", combine_search_spaces(autos, tsk("penguins")), 256L)
@@ -35,7 +35,7 @@ test_that("random design is generated", {
 })
 
 test_that("set design is generated", {
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
 
   autos = mlr_auto$mget(mlr_auto$keys())
   xdt = map_dtr(autos, function(auto) auto$design_set(tsk("penguins"), msr("classif.ce"), 10L), .fill = TRUE)
@@ -44,7 +44,7 @@ test_that("set design is generated", {
 })
 
 test_that("estimate memory works", {
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
 
   autos = mlr_auto$mget(mlr_auto$keys())
   memory = map_dbl(autos, function(auto) auto$estimate_memory(tsk("penguins")))

--- a/tests/testthat/test_LearnerClassifAuto.R
+++ b/tests/testthat/test_LearnerClassifAuto.R
@@ -9,7 +9,7 @@ test_that("LearnerClassifAuto is initialized", {
 test_that("only lda fails", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   task = tsk("penguins")
   expect_error(lrn("classif.auto",
@@ -24,7 +24,7 @@ test_that("only lda fails", {
 test_that("only extra_trees fails", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   task = tsk("penguins")
   expect_error(lrn("classif.auto",
@@ -39,13 +39,17 @@ test_that("all learner on cpu work", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget(c("catboost", "glmnet", "kknn", "lightgbm", "ranger", "svm", "xgboost", "lda", "extra_trees")), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = c("catboost", "glmnet", "kknn", "lightgbm", "ranger", "svm", "xgboost", "lda", "extra_trees"),
     small_data_size = 1,
     resampling = rsmp("holdout"),
@@ -65,13 +69,17 @@ test_that("memory limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("spam")
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = c("ranger", "xgboost", "catboost", "kknn"),
     memory_limit = 5,
     small_data_size = 100,
@@ -92,13 +100,17 @@ test_that("small data set switch works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed("glmnet")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = "glmnet",
     small_data_size = 1000,
     small_data_resampling = rsmp("cv", folds = 2),
@@ -118,13 +130,17 @@ test_that("large data set switch works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = c("catboost", "glmnet", "kknn", "lightgbm", "ranger", "svm", "xgboost", "lda", "extra_trees"),
     initial_design_type = "sobol",
     large_data_size = 100,
@@ -146,13 +162,17 @@ test_that("resample works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed("glmnet")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = "glmnet",
     small_data_size = 1,
     resampling = rsmp("holdout"),
@@ -171,13 +191,17 @@ test_that("best initial design works with evals terminator", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = c("kknn", "glmnet"),
     initial_design_set = 1,
     small_data_size = 1,
@@ -194,13 +218,17 @@ test_that("initial design runtime limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = "glmnet",
     small_data_size = 1,
     initial_design_type = "random",
@@ -216,13 +244,17 @@ test_that("devices works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     devices = "cpu",
     measure = msr("classif.ce"),
     terminator = trm("evals", n_evals = 10),
@@ -239,13 +271,17 @@ test_that("devices works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto",
+    rush = rush,
     devices = "cuda",
     measure = msr("classif.ce"),
     terminator = trm("evals", n_evals = 10),
@@ -261,14 +297,18 @@ test_that("lightgbm time limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("spam")
 
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = "lightgbm",
     learner_timeout = 1,
     measure = msr("classif.ce"),
@@ -287,14 +327,18 @@ test_that("xgboost time limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("spam")
 
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = "xgboost",
     learner_timeout = 1,
     measure = msr("classif.ce"),
@@ -313,14 +357,18 @@ test_that("adaptive design works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
 
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = c("kknn", "ranger"),
     small_data_size = 1,
     measure = msr("classif.ce"),
@@ -341,14 +389,18 @@ test_that("adaptive design works", {
   skip_on_cran()
   skip_if_not_installed("rush")
   skip_if_not_installed(all_packages)
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
 
   learner = lrn("classif.auto",
+    rush = rush,
     learner_ids = c("lda", "ranger"),
     small_data_size = 1,
     measure = msr("classif.ce"),
@@ -364,7 +416,3 @@ test_that("adaptive design works", {
 
   expect_class(learner$train(task), "LearnerClassifAuto")
 })
-
-
-
-

--- a/tests/testthat/test_LearnerClassifAuto.R
+++ b/tests/testthat/test_LearnerClassifAuto.R
@@ -23,6 +23,7 @@ test_that("only lda fails", {
 
 test_that("only extra_trees fails", {
   skip_on_cran()
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("extra_trees"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 
@@ -37,7 +38,7 @@ test_that("only extra_trees fails", {
 
 test_that("all learner on cpu work", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget(c("catboost", "glmnet", "kknn", "lightgbm", "ranger", "svm", "xgboost", "lda", "extra_trees")), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget(c("catboost", "glmnet", "kknn", "lightgbm", "ranger", "svm", "xgboost", "lda", "extra_trees")), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 
@@ -68,7 +69,7 @@ test_that("all learner on cpu work", {
 test_that("memory limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -129,7 +130,7 @@ test_that("small data set switch works", {
 test_that("large data set switch works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -190,7 +191,7 @@ test_that("resample works", {
 test_that("best initial design works with evals terminator", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -217,7 +218,7 @@ test_that("best initial design works with evals terminator", {
 test_that("initial design runtime limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -243,7 +244,7 @@ test_that("initial design runtime limit works", {
 test_that("devices works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -270,7 +271,7 @@ test_that("devices works", {
   skip_if(TRUE)
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -296,7 +297,7 @@ test_that("devices works", {
 test_that("lightgbm time limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -326,7 +327,7 @@ test_that("lightgbm time limit works", {
 test_that("xgboost time limit works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -356,7 +357,7 @@ test_that("xgboost time limit works", {
 test_that("adaptive design works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()
@@ -388,7 +389,7 @@ test_that("adaptive design works", {
 test_that("adaptive design works", {
   skip_on_cran()
   skip_if_not_installed("rush")
-  skip_if_not_installed(all_packages)
+  skip_if_not_all_installed(all_packages)
   skip_if_no_redis()
 
   rush = start_rush()

--- a/tests/testthat/test_LearnerClassifAutoCatboost.R
+++ b/tests/testthat/test_LearnerClassifAutoCatboost.R
@@ -2,13 +2,17 @@ test_that("LearnerClassifAutoCatboost works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("catboost"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto_catboost",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),
@@ -22,5 +26,3 @@ test_that("LearnerClassifAutoCatboost works", {
 
   expect_class(learner$train(task), "LearnerClassifAutoCatboost")
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoCatboost.R
+++ b/tests/testthat/test_LearnerClassifAutoCatboost.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoCatboost works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("catboost"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("catboost"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoFTTransformer.R
+++ b/tests/testthat/test_LearnerClassifAutoFTTransformer.R
@@ -10,8 +10,11 @@ test_that("LearnerClassifAutoFTTransformer works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "mirai")
-    mirai::daemons(2)
+    rush = start_rush()
+    on.exit({
+      rush$reset()
+      mirai::daemons(0)
+    })
 
     mirai::everywhere({
       Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -20,7 +23,8 @@ test_that("LearnerClassifAutoFTTransformer works", {
     task = tsk("penguins")
     task$filter(c(1, 153, 277))
 
-    learner = lrn("classif.auto_ft_transformer",
+    learner = lrn(
+      "classif.auto_ft_transformer",
       small_data_size = 1,
       resampling = rsmp("holdout"),
       measure = msr("classif.ce"),
@@ -29,7 +33,9 @@ test_that("LearnerClassifAutoFTTransformer works", {
       initial_design_size = 2,
       encapsulate_learner = FALSE,
       encapsulate_mbo = FALSE,
-      check_learners = FALSE)
+      check_learners = FALSE,
+      rush = rush
+    )
 
     expect_class(learner$train(task), "LearnerClassifAutoFTTransformer")
     TRUE

--- a/tests/testthat/test_LearnerClassifAutoFTTransformer.R
+++ b/tests/testthat/test_LearnerClassifAutoFTTransformer.R
@@ -2,7 +2,7 @@ test_that("LearnerClassifAutoFTTransformer works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("ft_transformer"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -10,7 +10,7 @@ test_that("LearnerClassifAutoFTTransformer works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -35,5 +35,3 @@ test_that("LearnerClassifAutoFTTransformer works", {
     TRUE
   }))
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoFTTransformer.R
+++ b/tests/testthat/test_LearnerClassifAutoFTTransformer.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoFTTransformer works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("ft_transformer"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("ft_transformer"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoFastai.R
+++ b/tests/testthat/test_LearnerClassifAutoFastai.R
@@ -1,7 +1,7 @@
 test_that("LearnerClassifAutoFastai works", {
   skip_if(TRUE)
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("fastai"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("fastai"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoFastai.R
+++ b/tests/testthat/test_LearnerClassifAutoFastai.R
@@ -3,7 +3,7 @@ test_that("LearnerClassifAutoFastai works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("fastai"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -11,7 +11,7 @@ test_that("LearnerClassifAutoFastai works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -36,5 +36,3 @@ test_that("LearnerClassifAutoFastai works", {
     expect_class(learner$train(task), "LearnerClassifAutoFastai")
   }))
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoGlmnet.R
+++ b/tests/testthat/test_LearnerClassifAutoGlmnet.R
@@ -2,13 +2,17 @@ test_that("LearnerClassifAutoGlmnet works", {
   skip_on_cran()
   skip_if_not_installed("glmnet")
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto_glmnet",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),

--- a/tests/testthat/test_LearnerClassifAutoKKNN.R
+++ b/tests/testthat/test_LearnerClassifAutoKKNN.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoKKNN works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("kknn"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("kknn"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoKKNN.R
+++ b/tests/testthat/test_LearnerClassifAutoKKNN.R
@@ -2,13 +2,17 @@ test_that("LearnerClassifAutoKKNN works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("kknn"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto_kknn",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),
@@ -22,5 +26,3 @@ test_that("LearnerClassifAutoKKNN works", {
 
   expect_class(learner$train(task), "LearnerClassifAutoKKNN")
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoLightGBM.R
+++ b/tests/testthat/test_LearnerClassifAutoLightGBM.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoLightGBM works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("lightgbm"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("lightgbm"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoLightGBM.R
+++ b/tests/testthat/test_LearnerClassifAutoLightGBM.R
@@ -2,13 +2,17 @@ test_that("LearnerClassifAutoLightGBM works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("lightgbm"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto_lightgbm",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),
@@ -22,5 +26,3 @@ test_that("LearnerClassifAutoLightGBM works", {
 
   expect_class(learner$train(task), "LearnerClassifAutoLightGBM")
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoMlp.R
+++ b/tests/testthat/test_LearnerClassifAutoMlp.R
@@ -10,8 +10,11 @@ test_that("LearnerClassifAutoMlp works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "mirai")
-    mirai::daemons(2)
+    rush = start_rush()
+    on.exit({
+      rush$reset()
+      mirai::daemons(0)
+    })
 
     mirai::everywhere({
       Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -20,7 +23,8 @@ test_that("LearnerClassifAutoMlp works", {
     task = tsk("penguins")
     task$filter(c(1, 153, 277))
 
-    learner = lrn("classif.auto_mlp",
+    learner = lrn(
+      "classif.auto_mlp",
       small_data_size = 1,
       resampling = rsmp("holdout"),
       measure = msr("classif.ce"),
@@ -29,7 +33,9 @@ test_that("LearnerClassifAutoMlp works", {
       initial_design_size = 2,
       encapsulate_learner = FALSE,
       encapsulate_mbo = FALSE,
-      check_learners = FALSE)
+      check_learners = FALSE,
+      rush = rush
+    )
 
     expect_class(learner$train(task), "LearnerClassifAutoMLP")
     TRUE

--- a/tests/testthat/test_LearnerClassifAutoMlp.R
+++ b/tests/testthat/test_LearnerClassifAutoMlp.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoMlp works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("mlp"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("mlp"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoMlp.R
+++ b/tests/testthat/test_LearnerClassifAutoMlp.R
@@ -2,7 +2,7 @@ test_that("LearnerClassifAutoMlp works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("mlp"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -10,7 +10,7 @@ test_that("LearnerClassifAutoMlp works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -35,5 +35,3 @@ test_that("LearnerClassifAutoMlp works", {
     TRUE
   }))
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoRanger.R
+++ b/tests/testthat/test_LearnerClassifAutoRanger.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoRanger works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("ranger"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("ranger"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoRanger.R
+++ b/tests/testthat/test_LearnerClassifAutoRanger.R
@@ -2,13 +2,17 @@ test_that("LearnerClassifAutoRanger works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("ranger"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto_ranger",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),
@@ -22,5 +26,3 @@ test_that("LearnerClassifAutoRanger works", {
 
   expect_class(learner$train(task), "LearnerClassifAutoRanger")
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoResNet.R
+++ b/tests/testthat/test_LearnerClassifAutoResNet.R
@@ -2,7 +2,7 @@ test_that("LearnerClassifAutoResNet works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("resnet"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -10,7 +10,7 @@ test_that("LearnerClassifAutoResNet works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -35,5 +35,3 @@ test_that("LearnerClassifAutoResNet works", {
     TRUE
   }))
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoResNet.R
+++ b/tests/testthat/test_LearnerClassifAutoResNet.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoResNet works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("resnet"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("resnet"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoResNet.R
+++ b/tests/testthat/test_LearnerClassifAutoResNet.R
@@ -10,8 +10,11 @@ test_that("LearnerClassifAutoResNet works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "mirai")
-    mirai::daemons(2)
+    rush = start_rush()
+    on.exit({
+      rush$reset()
+      mirai::daemons(0)
+    })
 
     mirai::everywhere({
       Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -20,7 +23,8 @@ test_that("LearnerClassifAutoResNet works", {
     task = tsk("penguins")
     task$filter(c(1, 153, 277))
 
-    learner = lrn("classif.auto_resnet",
+    learner = lrn(
+      "classif.auto_resnet",
       small_data_size = 1,
       resampling = rsmp("holdout"),
       measure = msr("classif.ce"),
@@ -29,7 +33,9 @@ test_that("LearnerClassifAutoResNet works", {
       initial_design_size = 2,
       encapsulate_learner = FALSE,
       encapsulate_mbo = FALSE,
-      check_learners = FALSE)
+      check_learners = FALSE,
+      rush = rush
+    )
 
     expect_class(learner$train(task), "LearnerClassifAutoResNet")
     TRUE

--- a/tests/testthat/test_LearnerClassifAutoSVM.R
+++ b/tests/testthat/test_LearnerClassifAutoSVM.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoSVM works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("svm"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("svm"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoSVM.R
+++ b/tests/testthat/test_LearnerClassifAutoSVM.R
@@ -2,13 +2,17 @@ test_that("LearnerClassifAutoSVM works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("svm"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto_svm",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),
@@ -22,5 +26,3 @@ test_that("LearnerClassifAutoSVM works", {
 
   expect_class(learner$train(task), "LearnerClassifAutoSVM")
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoTabpfn.R
+++ b/tests/testthat/test_LearnerClassifAutoTabpfn.R
@@ -3,7 +3,7 @@ test_that("LearnerClassifAutoTabpfn works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("tabpfn"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -11,7 +11,7 @@ test_that("LearnerClassifAutoTabpfn works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -35,5 +35,3 @@ test_that("LearnerClassifAutoTabpfn works", {
     expect_class(learner$train(task), "LearnerClassifAutoTabPFN")
   }))
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoTabpfn.R
+++ b/tests/testthat/test_LearnerClassifAutoTabpfn.R
@@ -1,7 +1,7 @@
 test_that("LearnerClassifAutoTabpfn works", {
   skip_if(TRUE)
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("tabpfn"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("tabpfn"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerClassifAutoXgboost.R
+++ b/tests/testthat/test_LearnerClassifAutoXgboost.R
@@ -2,13 +2,17 @@ test_that("LearnerClassifAutoXgboost works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("xgboost"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("penguins")
   learner = lrn("classif.auto_xgboost",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("classif.ce"),
@@ -22,5 +26,3 @@ test_that("LearnerClassifAutoXgboost works", {
 
   expect_class(learner$train(task), "LearnerClassifAutoXgboost")
 })
-
-

--- a/tests/testthat/test_LearnerClassifAutoXgboost.R
+++ b/tests/testthat/test_LearnerClassifAutoXgboost.R
@@ -1,6 +1,6 @@
 test_that("LearnerClassifAutoXgboost works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("xgboost"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("xgboost"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAuto.R
+++ b/tests/testthat/test_LearnerRegrAuto.R
@@ -8,7 +8,7 @@ test_that("LearnerRegrAuto is initialized", {
 
 test_that("all learner on cpu work", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget(c("catboost", "glmnet", "lightgbm", "ranger", "svm", "xgboost", "extra_trees")), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget(c("catboost", "glmnet", "lightgbm", "ranger", "svm", "xgboost", "extra_trees")), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAuto.R
+++ b/tests/testthat/test_LearnerRegrAuto.R
@@ -10,13 +10,17 @@ test_that("all learner on cpu work", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget(c("catboost", "glmnet", "lightgbm", "ranger", "svm", "xgboost", "extra_trees")), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto",
+    rush = rush,
     learner_ids = c("catboost", "glmnet", "lightgbm", "ranger", "svm", "xgboost", "extra_trees"),
     small_data_size = 1,
     resampling = rsmp("holdout"),

--- a/tests/testthat/test_LearnerRegrAutoCatboost.R
+++ b/tests/testthat/test_LearnerRegrAutoCatboost.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoCatboost works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("catboost"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("catboost"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoCatboost.R
+++ b/tests/testthat/test_LearnerRegrAutoCatboost.R
@@ -2,13 +2,17 @@ test_that("LearnerRegrAutoCatboost works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("catboost"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto_catboost",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),

--- a/tests/testthat/test_LearnerRegrAutoFTTransformer.R
+++ b/tests/testthat/test_LearnerRegrAutoFTTransformer.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoFTTransformer works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("ft_transformer"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("ft_transformer"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoFTTransformer.R
+++ b/tests/testthat/test_LearnerRegrAutoFTTransformer.R
@@ -2,7 +2,7 @@ test_that("LearnerRegrAutoFTTransformer works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("ft_transformer"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -10,7 +10,7 @@ test_that("LearnerRegrAutoFTTransformer works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -34,5 +34,3 @@ test_that("LearnerRegrAutoFTTransformer works", {
     TRUE
   }))
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoFTTransformer.R
+++ b/tests/testthat/test_LearnerRegrAutoFTTransformer.R
@@ -10,8 +10,11 @@ test_that("LearnerRegrAutoFTTransformer works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "mirai")
-    mirai::daemons(2)
+    rush = start_rush()
+    on.exit({
+      rush$reset()
+      mirai::daemons(0)
+    })
 
     mirai::everywhere({
       Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -19,7 +22,8 @@ test_that("LearnerRegrAutoFTTransformer works", {
 
     task = tsk("mtcars")
 
-    learner = lrn("regr.auto_ft_transformer",
+    learner = lrn(
+      "regr.auto_ft_transformer",
       small_data_size = 1,
       resampling = rsmp("holdout"),
       measure = msr("regr.rmse"),
@@ -28,7 +32,9 @@ test_that("LearnerRegrAutoFTTransformer works", {
       initial_design_size = 2,
       encapsulate_learner = FALSE,
       encapsulate_mbo = FALSE,
-      check_learners = FALSE)
+      check_learners = FALSE,
+      rush = rush
+    )
 
     expect_class(learner$train(task), "LearnerRegrAutoFTTransformer")
     TRUE

--- a/tests/testthat/test_LearnerRegrAutoGlmnet.R
+++ b/tests/testthat/test_LearnerRegrAutoGlmnet.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoGlmnet works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("glmnet"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("glmnet"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoGlmnet.R
+++ b/tests/testthat/test_LearnerRegrAutoGlmnet.R
@@ -2,13 +2,17 @@ test_that("LearnerRegrAutoGlmnet works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("glmnet"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto_glmnet",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),
@@ -22,5 +26,3 @@ test_that("LearnerRegrAutoGlmnet works", {
 
   expect_class(learner$train(task), "LearnerRegrAutoGlmnet")
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoKKNN.R
+++ b/tests/testthat/test_LearnerRegrAutoKKNN.R
@@ -2,13 +2,17 @@ test_that("LearnerRegrAutoKKNN works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("kknn"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto_kknn",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),
@@ -22,5 +26,3 @@ test_that("LearnerRegrAutoKKNN works", {
 
   expect_class(learner$train(task), "LearnerRegrAutoKKNN")
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoKKNN.R
+++ b/tests/testthat/test_LearnerRegrAutoKKNN.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoKKNN works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("kknn"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("kknn"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoLightGBM.R
+++ b/tests/testthat/test_LearnerRegrAutoLightGBM.R
@@ -2,13 +2,17 @@ test_that("LearnerRegrAutoLightGBM works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("lightgbm"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto_lightgbm",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),
@@ -22,5 +26,3 @@ test_that("LearnerRegrAutoLightGBM works", {
 
   expect_class(learner$train(task), "LearnerRegrAutoLightGBM")
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoLightGBM.R
+++ b/tests/testthat/test_LearnerRegrAutoLightGBM.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoLightGBM works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("lightgbm"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("lightgbm"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoMlp.R
+++ b/tests/testthat/test_LearnerRegrAutoMlp.R
@@ -10,8 +10,11 @@ test_that("LearnerRegrAutoMlp works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "mirai")
-    mirai::daemons(2)
+    rush = start_rush()
+    on.exit({
+      rush$reset()
+      mirai::daemons(0)
+    })
 
     mirai::everywhere({
       Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -19,7 +22,8 @@ test_that("LearnerRegrAutoMlp works", {
 
     task = tsk("mtcars")
 
-    learner = lrn("regr.auto_mlp",
+    learner = lrn(
+      "regr.auto_mlp",
       small_data_size = 1,
       resampling = rsmp("holdout"),
       measure = msr("regr.rmse"),
@@ -28,7 +32,9 @@ test_that("LearnerRegrAutoMlp works", {
       initial_design_size = 2,
       encapsulate_learner = FALSE,
       encapsulate_mbo = FALSE,
-      check_learners = FALSE)
+      check_learners = FALSE,
+      rush = rush
+    )
 
     expect_class(learner$train(task), "LearnerRegrAutoMLP")
     TRUE

--- a/tests/testthat/test_LearnerRegrAutoMlp.R
+++ b/tests/testthat/test_LearnerRegrAutoMlp.R
@@ -2,7 +2,7 @@ test_that("LearnerRegrAutoMlp works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("mlp"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -10,7 +10,7 @@ test_that("LearnerRegrAutoMlp works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -34,5 +34,3 @@ test_that("LearnerRegrAutoMlp works", {
     TRUE
   }))
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoMlp.R
+++ b/tests/testthat/test_LearnerRegrAutoMlp.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoMlp works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("mlp"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("mlp"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoRanger.R
+++ b/tests/testthat/test_LearnerRegrAutoRanger.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoRanger works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("ranger"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("ranger"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoRanger.R
+++ b/tests/testthat/test_LearnerRegrAutoRanger.R
@@ -2,13 +2,17 @@ test_that("LearnerRegrAutoRanger works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("ranger"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto_ranger",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),
@@ -22,5 +26,3 @@ test_that("LearnerRegrAutoRanger works", {
 
   expect_class(learner$train(task), "LearnerRegrAutoRanger")
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoResNet.R
+++ b/tests/testthat/test_LearnerRegrAutoResNet.R
@@ -2,7 +2,7 @@ test_that("LearnerRegrAutoResNet works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("resnet"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -10,7 +10,7 @@ test_that("LearnerRegrAutoResNet works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -34,5 +34,3 @@ test_that("LearnerRegrAutoResNet works", {
     TRUE
   }))
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoResNet.R
+++ b/tests/testthat/test_LearnerRegrAutoResNet.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoResNet works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("resnet"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("resnet"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoResNet.R
+++ b/tests/testthat/test_LearnerRegrAutoResNet.R
@@ -10,8 +10,11 @@ test_that("LearnerRegrAutoResNet works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "mirai")
-    mirai::daemons(2)
+    rush = start_rush()
+    on.exit({
+      rush$reset()
+      mirai::daemons(0)
+    })
 
     mirai::everywhere({
       Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -19,7 +22,8 @@ test_that("LearnerRegrAutoResNet works", {
 
     task = tsk("mtcars")
 
-    learner = lrn("regr.auto_resnet",
+    learner = lrn(
+      "regr.auto_resnet",
       small_data_size = 1,
       resampling = rsmp("holdout"),
       measure = msr("regr.rmse"),
@@ -28,7 +32,9 @@ test_that("LearnerRegrAutoResNet works", {
       initial_design_size = 2,
       encapsulate_learner = FALSE,
       encapsulate_mbo = FALSE,
-      check_learners = FALSE)
+      check_learners = FALSE,
+      rush = rush
+    )
 
     expect_class(learner$train(task), "LearnerRegrAutoResNet")
     TRUE

--- a/tests/testthat/test_LearnerRegrAutoSVM.R
+++ b/tests/testthat/test_LearnerRegrAutoSVM.R
@@ -2,13 +2,17 @@ test_that("LearnerRegrAutoSVM works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("svm"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto_svm",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),

--- a/tests/testthat/test_LearnerRegrAutoSVM.R
+++ b/tests/testthat/test_LearnerRegrAutoSVM.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoSVM works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("svm"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("svm"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoTabpfn.R
+++ b/tests/testthat/test_LearnerRegrAutoTabpfn.R
@@ -1,7 +1,7 @@
 test_that("LearnerRegrAutoTabpfn works", {
   skip_if(TRUE)
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("tabpfn"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("tabpfn"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 

--- a/tests/testthat/test_LearnerRegrAutoTabpfn.R
+++ b/tests/testthat/test_LearnerRegrAutoTabpfn.R
@@ -3,7 +3,7 @@ test_that("LearnerRegrAutoTabpfn works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("tabpfn"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
   expect_true(callr::r(function() {
     Sys.setenv(RETICULATE_PYTHON = "managed")
@@ -11,7 +11,7 @@ test_that("LearnerRegrAutoTabpfn works", {
     library(testthat)
     library(checkmate)
 
-    rush_plan(n_workers = 2, worker_type = "remote")
+    rush_plan(n_workers = 2, worker_type = "mirai")
     mirai::daemons(2)
 
     mirai::everywhere({
@@ -35,5 +35,3 @@ test_that("LearnerRegrAutoTabpfn works", {
     TRUE
   }))
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoXgboost.R
+++ b/tests/testthat/test_LearnerRegrAutoXgboost.R
@@ -2,13 +2,17 @@ test_that("LearnerRegrAutoXgboost works", {
   skip_on_cran()
   skip_if_not_installed(unlist(map(mlr_auto$mget("xgboost"), "packages")))
   skip_if_not_installed("rush")
-  flush_redis()
+  skip_if_no_redis()
 
-  rush_plan(n_workers = 2, worker_type = "remote")
-  mirai::daemons(2)
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
 
   task = tsk("mtcars")
   learner = lrn("regr.auto_xgboost",
+    rush = rush,
     small_data_size = 1,
     resampling = rsmp("holdout"),
     measure = msr("regr.rmse"),
@@ -22,5 +26,3 @@ test_that("LearnerRegrAutoXgboost works", {
 
   expect_class(learner$train(task), "LearnerRegrAutoXgboost")
 })
-
-

--- a/tests/testthat/test_LearnerRegrAutoXgboost.R
+++ b/tests/testthat/test_LearnerRegrAutoXgboost.R
@@ -1,6 +1,6 @@
 test_that("LearnerRegrAutoXgboost works", {
   skip_on_cran()
-  skip_if_not_installed(unlist(map(mlr_auto$mget("xgboost"), "packages")))
+  skip_if_not_all_installed(unlist(map(mlr_auto$mget("xgboost"), "packages")))
   skip_if_not_installed("rush")
   skip_if_no_redis()
 


### PR DESCRIPTION
Pass rush object explicitly to ti_async() instead of relying solely on the global plan. Update tests to use start_rush() helper with proper on.exit cleanup, replace deprecated worker_type "remote" with "mirai", and add skip_if_no_redis() for conditional test execution.