### PR TITLE
fix: cap early stopping patience below the training budget

### DIFF
--- a/R/Auto.R
+++ b/R/Auto.R
@@ -102,16 +102,24 @@ Auto = R6Class(
     },
 
     #' @description
-    #' Estimate the number of early stopping rounds.
-    early_stopping_rounds = function(task) {
+    #' Estimate the number of early stopping rounds (the patience) for a learner.
+    #' `budget` is the maximum number of training rounds (boosting iterations or epochs) the learner may use.
+    #' The patience is capped well below the budget, otherwise early stopping and validation-based internal tuning
+    #' can never trigger and the learner always trains for the full budget.
+    #'
+    #' @param budget (`integer(1)`)\cr
+    #'   Maximum number of training rounds (boosting iterations or epochs) the learner may use.
+    early_stopping_rounds = function(task, budget = Inf) {
       min_early_stopping_rounds = 20L
       max_early_stopping_rounds = 200L
 
-      if (task$nrow < 1e4) {
-        return(max_early_stopping_rounds)
+      patience = if (task$nrow < 1e4) {
+        max_early_stopping_rounds
+      } else {
+        floor(max(min_early_stopping_rounds, 1e4 / task$nrow * max_early_stopping_rounds))
       }
 
-      floor((max(min_early_stopping_rounds, 1e4 / task$nrow * max_early_stopping_rounds)))
+      min(patience, max(min_early_stopping_rounds, budget %/% 5L))
     },
 
     #' @description

--- a/R/AutoCatboost.R
+++ b/R/AutoCatboost.R
@@ -50,7 +50,7 @@ AutoCatboost = R6Class(
         sprintf("%s.catboost", task$task_type),
         id = "catboost",
         iterations = iterations,
-        early_stopping_rounds = self$early_stopping_rounds(task),
+        early_stopping_rounds = self$early_stopping_rounds(task, budget = iterations),
         use_best_model = TRUE,
         eval_metric = self$internal_measure(measure, task),
         task_type = task_type

--- a/R/AutoFTTransformer.R
+++ b/R/AutoFTTransformer.R
@@ -80,7 +80,7 @@ AutoFTTransformer = R6Class(
         sprintf("%s.ft_transformer", task$task_type),
         id = "ft_transformer",
         measures_valid = measure,
-        patience = self$early_stopping_rounds(task),
+        patience = self$early_stopping_rounds(task, budget = self$search_space(task)$upper[["ft_transformer.epochs"]]),
         batch_size = 32L,
         attention_n_heads = 8L,
         opt.param_groups = rtdl_param_groups,

--- a/R/AutoFastai.R
+++ b/R/AutoFastai.R
@@ -69,7 +69,7 @@ AutoFastai = R6Class(
       learner = LearnerClassifFastaiIsolated$new()
       learner$id = "fastai"
       learner$param_set$set_values(
-        patience = self$early_stopping_rounds(task),
+        patience = self$early_stopping_rounds(task, budget = self$search_space(task)$upper[["fastai.n_epoch"]]),
         layers = c(200, 100),
         eval_metric = self$internal_measure(measure, task)
       )

--- a/R/AutoLightgbm.R
+++ b/R/AutoLightgbm.R
@@ -41,10 +41,12 @@ AutoLightgbm = R6Class(
 
       device_type = if ("cuda" %in% devices) "gpu" else "cpu"
 
+      num_iterations = self$search_space(task)$upper[["lightgbm.num_iterations"]]
+
       learner = lrn(
         sprintf("%s.lightgbm", task$task_type),
         id = "lightgbm",
-        early_stopping_rounds = self$early_stopping_rounds(task),
+        early_stopping_rounds = self$early_stopping_rounds(task, budget = num_iterations),
         callbacks = list(cb_timeout_lightgbm(timeout * 0.9)),
         eval = self$internal_measure(measure, task),
         device_type = device_type

--- a/R/AutoMlp.R
+++ b/R/AutoMlp.R
@@ -48,7 +48,7 @@ AutoMlp = R6Class(
       learner$id = "mlp"
       learner$param_set$set_values(
         measures_valid = measure,
-        patience = self$early_stopping_rounds(task),
+        patience = self$early_stopping_rounds(task, budget = self$search_space(task)$upper[["mlp.epochs"]]),
         batch_size = 32L,
         device = device
       )

--- a/R/AutoResNet.R
+++ b/R/AutoResNet.R
@@ -46,7 +46,7 @@ AutoResNet = R6Class(
         sprintf("%s.tab_resnet", task$task_type),
         id = "resnet",
         measures_valid = measure,
-        patience = self$early_stopping_rounds(task),
+        patience = self$early_stopping_rounds(task, budget = self$search_space(task)$upper[["resnet.epochs"]]),
         batch_size = 32L,
         device = device
       )

--- a/R/AutoXgboost.R
+++ b/R/AutoXgboost.R
@@ -40,14 +40,16 @@ AutoXgboost = R6Class(
 
       require_namespaces("mlr3learners")
 
+      nrounds = self$search_space(task)$upper[["xgboost.nrounds"]]
+
       learner = lrn(
         sprintf("%s.xgboost", task$task_type),
         id = "xgboost",
         booster = "gbtree",
-        early_stopping_rounds = self$early_stopping_rounds(task),
+        early_stopping_rounds = self$early_stopping_rounds(task, budget = nrounds),
         callbacks = list(cb_timeout_xgboost(timeout * 0.9)),
         eval_metric = self$internal_measure(measure, task),
-        nrounds = 5000L
+        nrounds = nrounds
       )
       set_threads(learner, n_threads)
 

--- a/man/Auto.Rd
+++ b/man/Auto.Rd
@@ -120,16 +120,21 @@ Default is "cpu".}
 \if{html}{\out{<a id="method-Auto-early_stopping_rounds"></a>}}
 \if{latex}{\out{\hypertarget{method-Auto-early_stopping_rounds}{}}}
 \subsection{\code{Auto$early_stopping_rounds()}}{
-  Estimate the number of early stopping rounds.
+  Estimate the number of early stopping rounds (the patience) for a learner.
+\code{budget} is the maximum number of training rounds (boosting iterations or epochs) the learner may use.
+The patience is capped well below the budget, otherwise early stopping and validation-based internal tuning
+can never trigger and the learner always trains for the full budget.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Auto$early_stopping_rounds(task)}
+    \preformatted{Auto$early_stopping_rounds(task, budget = Inf)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{task}}{(\link[mlr3:Task]{mlr3::Task}).}
+      \item{\code{budget}}{(\code{integer(1)})\cr
+Maximum number of training rounds (boosting iterations or epochs) the learner may use.}
     }
     \if{html}{\out{</div>}}
   }


### PR DESCRIPTION
early_stopping_rounds() returned a fixed patience of 200 for tasks under 10k rows. For the torch and fastai learners, whose budget is capped at 100 epochs, patience exceeded the budget, so early stopping and validation-based internal tuning never triggered and models always trained the full budget.

Add a budget argument and cap patience at max(20, budget %/% 5) so it stays below the training budget. Boosting learners (budget 1000-5000) are unchanged; torch learners now use a patience of 20.