### PR TITLE
build: install mlr3extralearners from github

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     lightgbm,
     MASS,
     mirai,
-    mlr3extralearners,
+    mlr3extralearners (>= 1.6.0.9000),
     mlr3torch (>= 0.3.3),
     mlr3viz,
     ranger,
@@ -56,6 +56,7 @@ Suggests:
     xgboost (>= 3.2.1.1)
 Remotes:
     mlr-org/bbotk,
+    mlr-org/mlr3extralearners,
     mlr-org/mlr3mbo@adbo_subspaces,
     mlr-org/rush,
     mlr-org/mlr3tuning

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # mlr3automl (development version)
 
 * fix: The default configuration of the tabpfn learner in the initial design now matches TabPFN-3. The number of estimators changed from 4 to 8 and the softmax temperature from 1.0 to 0.9, which were the defaults of TabPFN-2.
-* fix: The tabpfn learner now sets `auto_scale_n_estimators = FALSE`. TabPFN-3 otherwise raises the number of estimators on its own when the task has more features than a single ensemble member sees, which overrides the tuned value.
+* fix: The tabpfn learner now sets `auto_scale_n_estimators = FALSE`. TabPFN-3 otherwise raises the number of estimators on its own when the task has more features than a single ensemble member sees, which overrides the tuned value. This requires `mlr3extralearners` 1.6.0.9000 or later, which is now the minimum version.
 * fix: Tuning on subspaces no longer fails when a learner has internally tuned parameters, e.g. `xgboost.nrounds` or `ft_transformer.epochs`. The subspaces are now derived from the search space of the tuning instance, which no longer holds the internally tuned parameters.
 * fix: The torch learners (mlp, resnet, and ft_transformer) now train on the CPU when `devices` does not include `"cuda"`. Previously they passed `device = "auto"` to `mlr3torch`, which selects the GPU whenever one is available, so they ignored `devices = "cpu"` and the resource accounting of the workers.
 * fix: The torch learners (mlp, resnet, and ft_transformer) now train with a batch size of 256 instead of 32 on the GPU. A batch of 32 rows leaves the GPU mostly idle because kernel launches and host to device transfers dominate the step time.


### PR DESCRIPTION
## Problem

[r-cmd-check on main](https://github.com/mlr-org/mlr3automl/actions/runs/31112845489) fails on both `release` and `devel` with 5 test errors, all the same:

```
Error in `self$assert(xs, sanitize = TRUE)`: Assertion on 'xs' failed:
Parameter 'auto_scale_n_estimators' not available.
```

- `test_LearnerClassifAuto.R:367` — devices works
- `test_LearnerClassifAutoTabPFN.R:12`, `:23`, `:56`
- `test_LearnerRegrAutoTabPFN.R:2`

## Cause

029225c sets `auto_scale_n_estimators = FALSE` in `AutoTabPFN$graph()` (`R/AutoTabPFN.R:103`).
That parameter was added to `mlr3extralearners` on 2026-07-23 in mlr-org/mlr3extralearners@7de5709 ("update TabPFN learners to match tabpfn 8.1.0 parameter sets").

CI resolves `mlr3extralearners` through `Additional_repositories: https://mlr-org.r-universe.dev`, and that r-universe copy is built from the **1.6.0 release tag** (`29dc858`, 2026-07-14) rather than from `main`, so it predates the parameter. Locally the package is installed from GitHub at 1.6.0.9000, which is why this only shows up in CI.

## Fix

- Add `mlr-org/mlr3extralearners` to `Remotes:`, alongside the other mlr-org development dependencies (`bbotk`, `mlr3mbo`, `rush`, `mlr3tuning`).
- Record `mlr3extralearners (>= 1.6.0.9000)` in `Suggests:` so a stale copy fails during dependency resolution with a clear message instead of surfacing as an opaque parameter error inside the tests.

Verified locally that `LearnerClassifTabPFNIsolated$new()` and `LearnerRegrTabPFNIsolated$new()` both accept `auto_scale_n_estimators = FALSE` at 1.6.0.9000, which is the exact call that fails in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)